### PR TITLE
🐛 해결, 던전 입장 확인 예외처리 완료

### DIFF
--- a/Scripts/GamePlay/Screen/DungeonBattleScreen.cs
+++ b/Scripts/GamePlay/Screen/DungeonBattleScreen.cs
@@ -38,11 +38,16 @@ namespace TextRPG
                     case "1":
                         BattleStart();
                         return;
-                    default:
+
+                    case "0":
                         return;
+
+                    default:
+                        Console.WriteLine("잘못된 입력입니다.");
+                        Thread.Sleep(75);
+                        continue;
                 }
             }
-
         }
         private void AppearEnemy()
         {


### PR DESCRIPTION
## 개요
던전 입장 확인에서, 오입력시 마을로 돌아감
## 작업 사항
예외처리, 오입력시에는 재입력 받게 함
## 변경 로직

## 관련 이슈

