### PR TITLE
🎨 : 스크린 리프레시 로직 변경 및 아이템 장착 로직 변경

### DIFF
--- a/Scripts/GameData/Enums.cs
+++ b/Scripts/GameData/Enums.cs
@@ -20,5 +20,5 @@ namespace TextRPG
 
     public enum EItemRank { DEFAULT, COMMON, RARE, EPIC }
 
-    public enum EMessageType { DEFAULT, ERROR }
+    public enum EMessageType { DEFAULT, ERROR, OTHERCLASSITEM }
 }

--- a/Scripts/GamePlay/Screen/ClassSelectionScreen.cs
+++ b/Scripts/GamePlay/Screen/ClassSelectionScreen.cs
@@ -7,10 +7,9 @@ namespace TextRPG
         //  Enum.GetNames(typeof(PlayerClass)).Length => PlayerClass 열거형의 길이를 반환
         public override void ScreenOn()
         {
-            Console.Clear();
-
             while (true)
             {
+                Console.Clear();
                 ClassSelectionText();
 
                 // 직업을 선택
@@ -29,7 +28,8 @@ namespace TextRPG
                 }
                 else
                 {
-                    Console.WriteLine("잘못된 입력입니다! 숫자를 다시 입력하세요.\n");
+                    Console.WriteLine("\n잘못된 입력입니다! 숫자를 다시 입력하세요.\n");
+                    Thread.Sleep(750);
                 }
             }
 

--- a/Scripts/GamePlay/Screen/EquipScreen.cs
+++ b/Scripts/GamePlay/Screen/EquipScreen.cs
@@ -8,28 +8,34 @@ namespace TextRPG
         public override void ScreenOn()
         {            
             while (true)
-            {
-                cursorPosition = 0;
+            {   
                 Console.Clear();
                 EquipText ();
                 MyActionText();
 
                 // 0. 뒤로 가기  장비 번호 : 장착/ 장착 해제
                 if (int.TryParse(Console.ReadLine(), out int input) && input >= 0 && input <= gm.Player.PlayerEquipItems.Count)
-                {
-                    messageType = EMessageType.DEFAULT;
+                {   
                     if (input == 0) 
                     {                        
                         return;
-                    }
+                    }                    
 
                     EquipItem equipItem = gm.Player.PlayerEquipItems[input - 1];
-                    Equip(equipItem);                   
+
+                    if(equipItem.UnitType == gm.Player.ePlayerClass || equipItem.UnitType == EUnitType.DEFAULT) // 플레이어 직업장비or공용장비
+                    {
+                        Equip(equipItem);
+                    }
+                    else
+                    {
+                        SystemMessageText(EMessageType.OTHERCLASSITEM);                        
+                    }
                 }
                 else
                 {
                     //Console.WriteLine("잘못된 입력입니다! 숫자를 제대로 입력하세요. \n");
-                    messageType = EMessageType.ERROR;
+                    SystemMessageText(EMessageType.ERROR);
                }
             }
         }
@@ -84,9 +90,7 @@ namespace TextRPG
 
             Console.WriteLine("0. 나가기");
 
-            Console.WriteLine();
-            cursorPosition += 8;
-
+            Console.WriteLine();   
         }
     }
 }

--- a/Scripts/GamePlay/Screen/InventoryScreen.cs
+++ b/Scripts/GamePlay/Screen/InventoryScreen.cs
@@ -15,8 +15,7 @@ namespace TextRPG
         public override void ScreenOn()
         {            
             while (true)
-            {
-                cursorPosition = 0;
+            {   
                 Console.Clear();
                 InventoryText();
                 MyActionText();
@@ -24,23 +23,19 @@ namespace TextRPG
                 // 1: 장착 관리, 2: 나가기
                 if (int.TryParse(Console.ReadLine(), out int input) && input >= 0 && input <= 1)
                 {
-                    messageType = EMessageType.DEFAULT;
                     switch (input)
                     {
                         case 1:
                             equipScreen.ScreenOn();                            
                             break;
                         case 0:                            
-                            return;
-                        default:
-                            messageType = EMessageType.ERROR;
-                            break;
+                            return;                        
                     }                    
                 }
                 else
                 {
                     //Console.WriteLine("\n잘못된 입력입니다! 로비로 돌아갈려면 0번을 입력하세요. \n");
-                    messageType = EMessageType.ERROR;
+                    SystemMessageText(EMessageType.ERROR);
                 }
             }
         }
@@ -65,8 +60,7 @@ namespace TextRPG
             Console.WriteLine("1. 장착 관리");
             Console.WriteLine("0. 나가기");
 
-            Console.WriteLine();
-            cursorPosition += 9;
+            Console.WriteLine();            
         }
 
     }

--- a/Scripts/GamePlay/Screen/LobbyScreen.cs
+++ b/Scripts/GamePlay/Screen/LobbyScreen.cs
@@ -23,16 +23,14 @@ namespace TextRPG
         public override void ScreenOn()
         {
             while (true)
-            {
-                cursorPosition = 0;
+            {   
                 Console.Clear();
                 LobbyText();
                 MyActionText();
 
                 // 1, 2, 3만 입력 받을 수 있게 함 , 테스트를 위해 범위를 6 에서 7로 조정
                 if (int.TryParse(Console.ReadLine(), out int input) && input >= 0 && input < 6)
-                {
-                    messageType = EMessageType.DEFAULT;
+                {   
                     switch (input)
                     {
                         case 0:
@@ -58,7 +56,7 @@ namespace TextRPG
                 else
                 {
                     //Console.WriteLine("잘못된 입력입니다! 1부터 3까지의 숫자를 다시 입력하세요.\n");
-                    messageType = EMessageType.ERROR;
+                    SystemMessageText(EMessageType.ERROR);
                 }
 
             }
@@ -82,8 +80,7 @@ namespace TextRPG
 
             Console.WriteLine("0. 저장 및 나가기");
 
-            Console.WriteLine();
-            cursorPosition += 12;
+            Console.WriteLine();            
         }
     }
 }

--- a/Scripts/GamePlay/Screen/Screen.cs
+++ b/Scripts/GamePlay/Screen/Screen.cs
@@ -8,18 +8,14 @@ namespace TextRPG
     public  abstract class Screen
     {
         protected ItemDataManager dm;
-        protected GameManager gm;
-        protected EMessageType messageType;
-        protected int cursorPosition;
+        protected GameManager gm;        
 
         protected static int playerInput;
         
         public Screen()
         {
             dm = ItemDataManager.instance;
-            gm = GameManager.instance;
-            messageType = EMessageType.DEFAULT;
-            cursorPosition = 0;
+            gm = GameManager.instance;               
         }
 
         // 5.1 J => 장비 추가로 인한 리팩토링
@@ -53,8 +49,7 @@ namespace TextRPG
                 Console.Write($"방어력 {equipItem.DefValue} ");
             }
 
-            Console.WriteLine($"|\t{equipItem.Desc}");
-            cursorPosition++;
+            Console.WriteLine($"|\t{equipItem.Desc}");            
         }
 
 
@@ -62,18 +57,23 @@ namespace TextRPG
         protected void MyActionText()
         {
             Console.WriteLine("원하시는 행동을 입력해주세요.");
-            Console.Write(">> ");
-            cursorPosition++;
-                        
-            switch(messageType)
+            Console.Write(">> ");            
+        }
+
+        protected void SystemMessageText(EMessageType messageType)
+        {
+            switch (messageType)
             {
                 case EMessageType.DEFAULT:
                     return;
                 case EMessageType.ERROR:
                     Console.WriteLine("\n\n잘못된 입력입니다");
                     break;
+                case EMessageType.OTHERCLASSITEM:
+                    Console.WriteLine("\n\n현재 직업에 맞지 않는 아이템입니다.");
+                    break;
             }
-            Console.SetCursorPosition(3, cursorPosition);
+            Thread.Sleep(750);
         }
 
         public abstract void ScreenOn();

--- a/Scripts/GamePlay/Screen/StatusScreen.cs
+++ b/Scripts/GamePlay/Screen/StatusScreen.cs
@@ -8,22 +8,20 @@ namespace TextRPG
         public override void ScreenOn()
         {
             while (true)
-            {
-                cursorPosition = 0;
+            {   
                 Console.Clear();
                 StatusText();
                 MyActionText();
 
                 // 0 입력 시 나가기
                 if (int.TryParse(Console.ReadLine(), out int input) && input == 0)
-                {
-                    messageType = EMessageType.DEFAULT;
+                {   
                     return;
                 }
                 else
                 {
                     //Console.WriteLine("잘못된 입력입니다! 로비로 돌아갈려면 0번을 입력하세요. \n");
-                    messageType = EMessageType.ERROR;
+                    SystemMessageText(EMessageType.ERROR);
                 }
             }
 
@@ -70,8 +68,7 @@ namespace TextRPG
 
             Console.WriteLine($"Gold : {gm.Player.Gold} G");
 
-            Console.WriteLine("\n0. 나가기\n");
-            cursorPosition += 21;
+            Console.WriteLine("\n0. 나가기\n");            
         }
     }
 }


### PR DESCRIPTION
## 개요

## 작업 사항
기존 스크린 리프레시 로직이 콘솔창 크기 변경으로 줄바꿈의 고정이 안되
Screen 클래스 내 SystemMessageText 함수로 메세지를 Threed.Sleep으로 처리하도록 변경 
아이템 장착 시 다른 직업 장비 선택 시 경고 메세지와 장착이 안되도록 변경

## 변경 로직

## 관련 이슈

