### PR TITLE
✨ 🐛  죽음 패널티, 결과창 전투 연결 부분 버그 수정

### DIFF
--- a/Scripts/GameData/PlayerRewards.cs
+++ b/Scripts/GameData/PlayerRewards.cs
@@ -1,0 +1,16 @@
+﻿namespace TextRPG
+{
+    public class PlayerRewards
+    {
+        public List<EquipItem> rewardEquipItems; // 던전 보상 추가 예정
+        public int totalGold;
+        public int currentGold;
+
+        public PlayerRewards()
+        {
+            rewardEquipItems = new List<EquipItem>();
+            totalGold = 0;
+            currentGold = 0;
+        }
+    }
+}

--- a/Scripts/GamePlay/Screen/DungeonBattleScreen.cs
+++ b/Scripts/GamePlay/Screen/DungeonBattleScreen.cs
@@ -84,28 +84,14 @@ namespace TextRPG
                 // 5.4 A input int화
                 if (int.TryParse(inputs, out input) && input >= 1 && input <= 3)
                 {
+                    gm.Dungeon.dif = (EDungeonDifficulty)input;
+                    winCounter += input;
                     break;
                 }
                 else
                 {
                     Console.WriteLine("잘못된 입력입니다. 다시 입력하세요.");
                 }
-            }
-
-            winCounter += input;
-
-            //5.3 A : 던전 난이도 Enum활용
-            switch (input)
-            {
-                case 1:
-                    gm.Dungeon.dif = EDungeonDifficulty.EASY;
-                    break;
-                case 2:
-                    gm.Dungeon.dif = EDungeonDifficulty.NORMAL;
-                    break;
-                case 3:
-                    gm.Dungeon.dif = EDungeonDifficulty.HARD;
-                    break;
             }
 
             Console.WriteLine($"선택된 난이도: {gm.Dungeon.dif}");
@@ -116,14 +102,24 @@ namespace TextRPG
 
         public void BattleStart() // 전투 시작
         {
+
             CheckForDifficulty();
             AppearEnemy();
             dungeonBattle();
 
-            if(playerInput == 1)
+            if (playerInput == 1)
             {
-                BattleStart();
+                if (winCounter >= 10)
+                {
+                    // 보스
+                }
+                else
+                {
+                    BattleStart();
+                    return;
+                }
             }
+
         }
 
         private void dungeonBattle()
@@ -357,7 +353,7 @@ namespace TextRPG
             enemies.Add(boss);  // 현재 전투 몬스터 리스트에 보스 추가
             dungeonBattle();
 
-        }
+        } 
 
 
         private void BattleEnd(bool isWin)

--- a/Scripts/GamePlay/Screen/DungeonBattleScreen.cs
+++ b/Scripts/GamePlay/Screen/DungeonBattleScreen.cs
@@ -7,7 +7,6 @@ namespace TextRPG
     public class DungeonBattleScreen : Screen
     {
         private List<Enemy> enemies;  // 여러 몬스터를 저장할 리스트
-        private bool isWin;
         private int winCounter = 0;  // 승리 횟수 카운터
         private bool returnToChooseEnemy = false; // 스킬 예외처리
 
@@ -45,6 +44,7 @@ namespace TextRPG
                 switch (choice)
                 {
                     case "1":
+                        dungeonResultScreen.RewardInit();
                         BattleStart();
                         return;
 
@@ -119,6 +119,11 @@ namespace TextRPG
             CheckForDifficulty();
             AppearEnemy();
             dungeonBattle();
+
+            if(playerInput == 1)
+            {
+                BattleStart();
+            }
         }
 
         private void dungeonBattle()
@@ -152,6 +157,7 @@ namespace TextRPG
                     if (gm.Player.Health <= 0)  // 플레이어가 사망한 경우, 패배 처리
                     {
                         BattleEnd(false);
+                        return;
                     }
                 }
             }

--- a/Scripts/GamePlay/Screen/DungeonResultScreen.cs
+++ b/Scripts/GamePlay/Screen/DungeonResultScreen.cs
@@ -19,7 +19,7 @@
 
         private void GameOverPanalty() // 게임 오버 시 패널티
         {
-            if (gm.Dungeon.PlayerRewards.rewardEquipItems[0] != null)
+            if (gm.Dungeon.PlayerRewards.rewardEquipItems.Count != 0)
             {
                 panaltyEquipItem = dm.GetRandomEquipItem(gm.Dungeon.PlayerRewards.rewardEquipItems);
                 gm.Player.AddEquipItem(panaltyEquipItem);
@@ -43,6 +43,7 @@
 
             while (true)
             {
+                Console.Clear();
 
                 switch (gm.Dungeon.DungeonResultType)
                 {
@@ -64,6 +65,7 @@
                     {
                         gm.Player.RecoveryMana(gm.Player.MaxMana);
                         gm.Player.RecoveryHealth(gm.Player.MaxHealth);
+                        SetDungeonReward();
                     }
 
                     playerInput = input; // Input 값 저장
@@ -84,7 +86,7 @@
 
             }
         }
-        private void DungeonReward() // 던전 보상
+        private void DungeonReward() // 던전 보상 (골드 및 장비 아이템 X)
         {
             reward = gm.Dungeon.GetDungeonReward();
 
@@ -96,7 +98,15 @@
             prevExp = gm.Player.Exp;
             gm.Player.ExpUp(gm.Dungeon.BattleExp);
         }
-
+        private void SetDungeonReward() // 골드 및 장비 아이템 획득
+        {
+            gm.Player.Gold += gm.Dungeon.PlayerRewards.totalGold;
+            
+            for(int i = 0; i < gm.Dungeon.PlayerRewards.rewardEquipItems.Count; i++)
+            {
+                gm.Player.AddEquipItem(gm.Dungeon.PlayerRewards.rewardEquipItems[i]);
+            }
+        }
         private void TitleText()
         {
             Console.WriteLine();

--- a/Scripts/GamePlay/Screen/DungeonResultScreen.cs
+++ b/Scripts/GamePlay/Screen/DungeonResultScreen.cs
@@ -73,18 +73,11 @@
 
                     playerInput = input; // Input 값 저장
 
-                    // 5.4 A : 배틀 계속이 아닌 로비로 돌아가는 현상 고치기 위해 넣음
-                    if (input == 1)
-                    {
-                        DungeonBattleScreen dungeonBattle = new DungeonBattleScreen();
-                        dungeonBattle.BattleStart(); ; // 바로 다음 스테이지로 이동
-                    }
-                    //
                     return;
                 }
                 else
                 {
-                    Console.WriteLine("잘못된 입력입니다! 숫자를 다시 입력하세요.\n");
+                    SystemMessageText(EMessageType.ERROR);
                 }
 
             }

--- a/Scripts/GamePlay/Screen/DungeonResultScreen.cs
+++ b/Scripts/GamePlay/Screen/DungeonResultScreen.cs
@@ -65,7 +65,10 @@
                     {
                         gm.Player.RecoveryMana(gm.Player.MaxMana);
                         gm.Player.RecoveryHealth(gm.Player.MaxHealth);
-                        SetDungeonReward();
+                        if(gm.Dungeon.DungeonResultType == EDungeonResultType.VICTORY)
+                        {
+                            SetDungeonReward();
+                        }
                     }
 
                     playerInput = input; // Input 값 저장
@@ -170,7 +173,7 @@
 
                 Console.WriteLine("[던전 보상]");
                 Console.WriteLine($"{panaltyGold} Gold");
-                Console.WriteLine($"{panaltyEquipItem} x 1");
+                Console.WriteLine($"{panaltyEquipItem.ItemName} x 1");
             }
 
             Console.WriteLine();

--- a/Scripts/GamePlay/Screen/DungeonResultScreen.cs
+++ b/Scripts/GamePlay/Screen/DungeonResultScreen.cs
@@ -1,7 +1,4 @@
-﻿
-using System.ComponentModel.Design;
-
-namespace TextRPG
+﻿namespace TextRPG
 {
     public class DungeonResultScreen : Screen
     {
@@ -10,12 +7,36 @@ namespace TextRPG
 
         private Reward reward;
 
+        private EquipItem panaltyEquipItem;
+        private int panaltyGold;
 
+        public void RewardInit() // 보상 초기화, 던전에 입장할 때 호출
+        {
+            gm.Dungeon.RewardInit();
+            panaltyEquipItem = null;
+            panaltyGold = 0;
+        }
+
+        private void GameOverPanalty() // 게임 오버 시 패널티
+        {
+            if (gm.Dungeon.PlayerRewards.rewardEquipItems[0] != null)
+            {
+                panaltyEquipItem = dm.GetRandomEquipItem(gm.Dungeon.PlayerRewards.rewardEquipItems);
+                gm.Player.AddEquipItem(panaltyEquipItem);
+                panaltyGold = gm.Dungeon.PlayerRewards.totalGold * 20 / 100;
+                gm.Player.Gold += panaltyGold;
+            }
+        }
         public override void ScreenOn()
         {
+
             if (gm.Dungeon.DungeonResultType != EDungeonResultType.RETIRE)
             {
                 DungeonReward();
+            }
+            else
+            {
+                GameOverPanalty();
             }
 
             Console.Clear();
@@ -39,7 +60,7 @@ namespace TextRPG
                 {
                     Console.Clear();
 
-                    if(input == 0) // 로비로 돌아갈 때 체력 및 마나 회복
+                    if (input == 0) // 로비로 돌아갈 때 체력 및 마나 회복
                     {
                         gm.Player.RecoveryMana(gm.Player.MaxMana);
                         gm.Player.RecoveryHealth(gm.Player.MaxHealth);
@@ -48,7 +69,7 @@ namespace TextRPG
                     playerInput = input; // Input 값 저장
 
                     // 5.4 A : 배틀 계속이 아닌 로비로 돌아가는 현상 고치기 위해 넣음
-                    if(input == 1)
+                    if (input == 1)
                     {
                         DungeonBattleScreen dungeonBattle = new DungeonBattleScreen();
                         dungeonBattle.BattleStart(); ; // 바로 다음 스테이지로 이동
@@ -67,17 +88,15 @@ namespace TextRPG
         {
             reward = gm.Dungeon.GetDungeonReward();
 
-            gm.Player.AddEquipItem(reward.rewardEquipItem);
-            if(reward.rewardConsumableItem != null)
+            if (reward.rewardConsumableItem != null)
             {
                 gm.Player.AddConsumableItem(reward.rewardConsumableItem.ItemName);
             }
-            gm.Player.Gold += reward.gold;
             prevLevel = gm.Player.Level;
             prevExp = gm.Player.Exp;
             gm.Player.ExpUp(gm.Dungeon.BattleExp);
         }
-       
+
         private void TitleText()
         {
             Console.WriteLine();
@@ -104,7 +123,7 @@ namespace TextRPG
 
             Console.WriteLine();
 
-            Console.WriteLine("[획득 아이템]");
+            Console.WriteLine("[던전 보상]");
             Console.WriteLine($"{reward.gold} Gold");
 
             if (reward.rewardEquipItem != null)
@@ -133,6 +152,16 @@ namespace TextRPG
             Console.WriteLine();
 
             Console.WriteLine($"클리어 실패 스테이지 : {gm.Dungeon.CurrentDungeonLevel}");
+
+            if (panaltyEquipItem != null)
+            {
+                Console.WriteLine();
+                Console.WriteLine("던전에서 얻은 대부분의 골드와 장비를 잃었습니다.");
+
+                Console.WriteLine("[던전 보상]");
+                Console.WriteLine($"{panaltyGold} Gold");
+                Console.WriteLine($"{panaltyEquipItem} x 1");
+            }
 
             Console.WriteLine();
 

--- a/Scripts/GamePlay/Screen/LobbyScreen.cs
+++ b/Scripts/GamePlay/Screen/LobbyScreen.cs
@@ -27,7 +27,7 @@ namespace TextRPG
             while (true)
             {   
                 Console.Clear();
-                creditScreen.ScreenOn();
+             //   creditScreen.ScreenOn();
 
                 LobbyText();
                 MyActionText();

--- a/Scripts/Manager/DungeonManager.cs
+++ b/Scripts/Manager/DungeonManager.cs
@@ -9,6 +9,8 @@ namespace TextRPG
         public RandomReward RandomReward { get; private set; }
         public int BattleExp {  get;  set; } // 전투 경험치 보상
         public int PrevHealth {  get; set; }
+        public PlayerRewards PlayerRewards { get; private set; }
+
 
         public DungeonManager()
         {
@@ -19,7 +21,18 @@ namespace TextRPG
         // 던전 보상 만드는 함수
         public Reward GetDungeonReward()
         {
-            return RandomReward.GetRandomReward();
+            Reward reward =  RandomReward.GetRandomReward();
+
+            PlayerRewards.rewardEquipItems.Add(reward.rewardEquipItem);
+            PlayerRewards.totalGold += reward.gold;
+            PlayerRewards.currentGold = reward.gold;
+
+            return reward;
+        }
+
+        public void StartDungeon()
+        {
+            PlayerRewards = new PlayerRewards();
         }
 
         /*

--- a/Scripts/Manager/DungeonManager.cs
+++ b/Scripts/Manager/DungeonManager.cs
@@ -30,7 +30,7 @@ namespace TextRPG
             return reward;
         }
 
-        public void StartDungeon()
+        public void RewardInit()
         {
             PlayerRewards = new PlayerRewards();
         }


### PR DESCRIPTION
## 개요

## 작업 사항

죽음 패널티, 결과창 전투 연결 부분 버그 수정

패널티 
- 해당 던전에서 지금까지 얻은 장비들 중 랜덤으로 하나만 보상
- 해당 던전에서 지금까지 얻은 골드 중 20%만 보상

## 변경 로직

## 관련 이슈

