### PR TITLE
⚡ 던전 배틀 스크린 싱글톤 화

### DIFF
--- a/Scripts/GameData/Player.cs
+++ b/Scripts/GameData/Player.cs
@@ -24,18 +24,18 @@ namespace TextRPG
         public Player(string name)
         {
             Name = name;
-            Level = 7;
-            Atk = 10000;
-            Def = 500;
-            MaxHealth = 10000;
+            Level = 1;
+            Atk = 10;
+            Def = 5;
+            MaxHealth = 100;
             Health = MaxHealth;
             Gold = 10000;
             AvoidChance = 10;
             CriticalChance = 16;
             CriticalDamage = 1.6f;
-            MaxMana = 10000;
+            MaxMana = 100;
             Mana = MaxMana;
-            Phase = 3;
+            Phase = 0;
             base.Skills = new List<Skill>();
             base.DeBuffs = new List<DeBuff>();
             PlayerEquipItems = new List<EquipItem>();

--- a/Scripts/GameData/Player.cs
+++ b/Scripts/GameData/Player.cs
@@ -24,18 +24,18 @@ namespace TextRPG
         public Player(string name)
         {
             Name = name;
-            Level = 1;
-            Atk = 10;
-            Def = 5;
-            MaxHealth = 100;
+            Level = 7;
+            Atk = 10000;
+            Def = 500;
+            MaxHealth = 10000;
             Health = MaxHealth;
             Gold = 10000;
             AvoidChance = 10;
             CriticalChance = 16;
             CriticalDamage = 1.6f;
-            MaxMana = 100;
+            MaxMana = 10000;
             Mana = MaxMana;
-            Phase = 0;
+            Phase = 3;
             base.Skills = new List<Skill>();
             base.DeBuffs = new List<DeBuff>();
             PlayerEquipItems = new List<EquipItem>();

--- a/Scripts/GamePlay/Screen/DungeonBattleScreen.cs
+++ b/Scripts/GamePlay/Screen/DungeonBattleScreen.cs
@@ -12,10 +12,26 @@ namespace TextRPG
         private bool BossClear = false; // 5.5 A 보스 클리어 여부
         private CreditScreen creditScreen; // 5.5 A 보스 클리어 추가, 크레딧 BattleEnd에 연결함
 
+        private static DungeonBattleScreen instance;
+
+
         private DungeonResultScreen dungeonResultScreen;
 
         //public delegate void TurnChange(); // 05.05 W 턴 전환용 핸들러
         //public event TurnChange? TurnChangeHandler;        
+
+        public static DungeonBattleScreen Instance
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    instance = new DungeonBattleScreen();
+                }
+
+                return instance;
+            }
+        }
 
         public DungeonBattleScreen()
         {
@@ -265,6 +281,7 @@ namespace TextRPG
             if (enemy.Health <= 0)
             {
                 Console.WriteLine($"[{enemy.Name}이(가) 쓰러졌습니다.]");
+                gm.QuestManager.SetMonsterQuest(enemy);
             }
 
         }

--- a/Scripts/GamePlay/Screen/DungeonResultScreen.cs
+++ b/Scripts/GamePlay/Screen/DungeonResultScreen.cs
@@ -74,6 +74,10 @@
                     }
 
                     playerInput = input; // Input 값 저장
+                    if (input == 1)
+                    {
+                        DungeonBattleScreen.Instance.BattleStart();
+                    }
                     return;
                 }
                 else

--- a/Scripts/GamePlay/Screen/LobbyScreen.cs
+++ b/Scripts/GamePlay/Screen/LobbyScreen.cs
@@ -8,7 +8,7 @@ namespace TextRPG
         private ShopScreen shopScreen;
         private DungeonResultScreen dungeonScreen;
         private QuestScreen questScreen;
-        private DungeonBattleScreen dungeonBattle;
+        // 5.5 A 던전배틀 싱글톤화
         // 5.5 A 크레딧 스크린 삭제, DungeonBattle클래스로 이동
         public LobbyScreen()
         {
@@ -17,7 +17,7 @@ namespace TextRPG
             shopScreen = new ShopScreen();
             dungeonScreen = new DungeonResultScreen();
             questScreen = new QuestScreen();
-            dungeonBattle = new DungeonBattleScreen();
+            // 5.5 A 던전배틀 싱글톤화
             // 5.5 A 크레딧 스크린 삭제, DungeonBattle클래스로 이동
         }
 
@@ -49,7 +49,7 @@ namespace TextRPG
                             shopScreen.ScreenOn();
                             break;
                         case 4:
-                            dungeonBattle.ScreenOn();
+                            DungeonBattleScreen.Instance.ScreenOn(); // 5.5 A 던전 배틀 싱글톤화
                             break;
                         case 5:
                             questScreen.ScreenOn();


### PR DESCRIPTION
## 개요
전투 계속 처리를 위한 싱글톤 처리
## 작업 사항

## 변경 로직
기존에 있던 던전배틀스크린을 새 객체로 생성해서 사용하던
LobbyScreen에 있던 던전배틀 스크린 초기화와, dungeonBattle.ScreenOn을 
DungeonBattle.instance.ScreenOn으로 변경
## 관련 이슈

