### PR TITLE
✨ 퀘스트 시스템, 던전배틀스크린과 연결

### DIFF
--- a/Scripts/GamePlay/Screen/DungeonBattleScreen.cs
+++ b/Scripts/GamePlay/Screen/DungeonBattleScreen.cs
@@ -342,6 +342,13 @@ namespace TextRPG
                 Console.WriteLine(initialSkillResult);
                 Thread.Sleep(1500);
 
+                // 5.5 A 스킬 공격시 사망에도 퀘스트 카운팅 추적
+                if (target.Health <= 0)
+                {
+                    Console.WriteLine($"[{target.Name}이(가) 쓰러졌습니다.]");
+                    gm.QuestManager.SetMonsterQuest(target);
+                }
+
                 // 나머지 타겟들에게 스킬 적용
                 int targetsHit = 1; // 첫 번째 타겟이 이미 공격받았으므로 1로 시작
                 foreach (var enemy in enemies.Where(e => e.Health > 0 && e != target))
@@ -354,6 +361,13 @@ namespace TextRPG
                     Console.WriteLine(skillResult);
                     Thread.Sleep(1500);
 
+                    // 5.5 A 만약 나머지 타겟의 체력이 0 이하라면 퀘스트 진행 업데이트
+                    if (enemy.Health <= 0)
+                    {
+                        Console.WriteLine($"[{enemy.Name}이(가) 쓰러졌습니다.]");
+                        gm.QuestManager.SetMonsterQuest(enemy);
+                    }
+
                     targetsHit++;
                 }
             }
@@ -364,6 +378,12 @@ namespace TextRPG
                 string skillResult = skill.CastSkill(gm.Player, target);
                 Console.WriteLine(skillResult);
                 Thread.Sleep(2000);
+                // 5.5 A 퀘스트 추적
+                if (target.Health <= 0)
+                {
+                    Console.WriteLine($"[{target.Name}이(가) 쓰러졌습니다.]");
+                    gm.QuestManager.SetMonsterQuest(target);
+                }
             }
             Console.Clear();
         }

--- a/Scripts/Manager/QuestManager.cs
+++ b/Scripts/Manager/QuestManager.cs
@@ -77,6 +77,7 @@ namespace TextRPG.Scripts
 
         public void SetMonsterQuest(Enemy deadEnemy)
         {
+            int deadEnemyIndex = EnemyDataManager.instance.MonsterDB.FindIndex(monster => monster.Name == deadEnemy.Name); // 5.6 A 몬스터 추적
             var oldQ = QuestSave[1];
             int currentQ = oldQ.QuestNumber;
             int current = oldQ.CurrentProgress; 
@@ -86,19 +87,13 @@ namespace TextRPG.Scripts
                 return;
             }
             else
-            {
-                if (currentQ - 1 == EnemyDataManager.instance.MonsterDB.IndexOf(deadEnemy))
+            {    // 5.6 A 몬스터 추적을 위한 코드 수정
+                if (currentQ - 1 == deadEnemyIndex || currentQ == 0)
                 {
                     var newQ = (oldQ.QuestType, oldQ.QuestNumber, ++oldQ.CurrentProgress);
-
-                    QuestSave[1] = newQ;
-                }else if (currentQ == 0)
-                {
-                    var newQ = (oldQ.QuestType, oldQ.QuestNumber, ++oldQ.CurrentProgress);
-
                     QuestSave[1] = newQ;
                 }
-            }
+            }   //
         }
     }
 }


### PR DESCRIPTION
## 개요
퀘스트 시스템, 던전배틀스크린과 연결
## 작업 사항
플레이어턴, 유즈셀렉티드 스킬에 몬스터 사망시 퀘스트 추적 넣음
## 변경 로직
퀘스트 메니저 SetMonsterQuest 메서드가
죽은 적을 추적하지 못해서 수정함

원본
```
public void SetMonsterQuest(Enemy deadEnemy)
{
    int deadEnemyIndex = EnemyDataManager.instance.MonsterDB.FindIndex(monster => monster.Name == deadEnemy.Name); // 5.6 A 몬스터 추적
    var oldQ = QuestSave[1];
    int currentQ = oldQ.QuestNumber;
    int current = oldQ.CurrentProgress; 

    if (current == -1)
    {
        return;
    }
    else
    {
        if (currentQ -1 == EnemyDataManager.instance.MonsterDB.IndexOf(deadEnemy))
        {
            var newQ = (oldQ.QuestType, oldQ.QuestNumber, ++oldQ.CurrentProgress);

            QuestSave[1] = newQ;
        }else if (currentQ == 0)
        {
            var newQ = (oldQ.QuestType, oldQ.QuestNumber, ++oldQ.CurrentProgress);

            QuestSave[1] = newQ;
        }
    }
}
```

수정본
```
public void SetMonsterQuest(Enemy deadEnemy)
{
    int deadEnemyIndex = EnemyDataManager.instance.MonsterDB.FindIndex(monster => monster.Name == deadEnemy.Name); // 5.6 A 몬스터 추적
    var oldQ = QuestSave[1];
    int currentQ = oldQ.QuestNumber;
    int current = oldQ.CurrentProgress; 

    if (current == -1)
    {
        return;
    }
    else
    {    // 5.6 A 몬스터 추적을 위한 코드 수정
        if (currentQ - 1 == deadEnemyIndex || currentQ == 0)
        {
            var newQ = (oldQ.QuestType, oldQ.QuestNumber, ++oldQ.CurrentProgress);
            QuestSave[1] = newQ;
        }
    }   //
}
```
## 관련 이슈

